### PR TITLE
Fixes error when the stacktrace is undefined

### DIFF
--- a/src/spec-display.js
+++ b/src/spec-display.js
@@ -99,7 +99,9 @@ SpecDisplay.prototype = {
       if (!assertions[i].passed()) {
         this.log('- '.failure + assertions[i].message.failure);
         if (this.displayStacktrace) {
-          this.log(this.filterStackTraces(assertions[i].trace.stack));
+          if (assertions[i].trace.stack) {
+            this.log(this.filterStackTraces(assertions[i].trace.stack));
+          }
         }
       }
     }


### PR DESCRIPTION
When a protractor test has a timeout the stacktrace value is not defined. This causes the following error output:
```
    some page
      ✗ should do something (0.039 secs)
        - timeout: timed out after 10 msec waiting for spec to complete

/home/0xR/workspace/node_modules/jasmine-spec-reporter/src/spec-display.js:110
    var lines = traces.split('\n');
                       ^
TypeError: Cannot call method 'split' of undefined
    at Object.SpecDisplay.filterStackTraces (/home/0xR/workspace/node_modules/jasmine-spec-reporter/src/spec-display.js:110:24)
    at Object.SpecDisplay.displayErrorMessages (/home/0xR/workspace/node_modules/jasmine-spec-reporter/src/spec-display.js:102:25)
    at Object.SpecDisplay.failed (/home/0xR/workspace/node_modules/jasmine-spec-reporter/src/spec-display.js:80:12)
    at Object.SpecReporter.reportSpecResults (/home/0xR/workspace/node_modules/jasmine-spec-reporter/src/jasmine-spec-reporter.js:85:20)
```

This change solves that issue.
