### PR TITLE
display the test name before it starts

### DIFF
--- a/src/display-processor.js
+++ b/src/display-processor.js
@@ -16,4 +16,8 @@ DisplayProcessor.prototype.displaySkippedSpec = function (spec, log) {
   return log;
 };
 
+DisplayProcessor.prototype.displayStartedSpec = function (spec, log) {
+  return spec.description;
+};
+
 module.exports = DisplayProcessor;

--- a/src/jasmine-spec-reporter.js
+++ b/src/jasmine-spec-reporter.js
@@ -69,6 +69,7 @@ SpecReporter.prototype = {
   },
 
   reportSpecStarting: function (spec) {
+    this.display.started(spec);
     this.metrics.startSpec();
   },
 

--- a/src/spec-display.js
+++ b/src/spec-display.js
@@ -11,6 +11,7 @@ var SpecDisplay = function (options, displayProcessors) {
   this.displaySkippedSpec = options.displaySkippedSpec || false;
   this.displayWithoutColors = options.colors === false;
   this.displayProcessors = displayProcessors;
+  this.displayStartedSpec = options.displayStartedSpec !== false;
 };
 
 SpecDisplay.prototype = {
@@ -55,6 +56,17 @@ SpecDisplay.prototype = {
       suite = suite.parentSuite;
     }
     return description;
+  },
+
+  started: function (spec) {
+    if (this.displayStartedSpec) {
+      this.ensureSuiteDisplayed(spec.suite);
+      var log = null;
+      this.displayProcessors.forEach(function (displayProcessor) {
+        log = displayProcessor.displayStartedSpec(spec, log);
+      });
+      this.log(log);
+    }
   },
 
   successful: function (spec) {


### PR DESCRIPTION
when running longer selenium tests, it's helpful to know which test is running before it finishes

NOTE:
* I didn't add any tests yet, but wanted to confirm this feature would be accepted
* I wasn't sure id `return spec.description;` was the correct way to do it in the default display processor 