### PR TITLE
Change metrics to 'hour' or 'hours'

### DIFF
--- a/spec/duration-format.spec.coffee
+++ b/spec/duration-format.spec.coffee
@@ -14,6 +14,7 @@ describe 'duration', ->
     expect(@formatDuration(60 * secs)).toBe '1 mins'
     expect(@formatDuration(61 * secs)).toBe '1 mins 1 secs'
     expect(@formatDuration(59 * mins)).toBe '59 mins'
-    expect(@formatDuration(60 * mins)).toBe '1 hours'
+    expect(@formatDuration(60 * mins)).toBe '1 hour'
+    expect(@formatDuration(1 * hours + 59 * mins)).toBe '1 hour 59 mins'
     expect(@formatDuration(3 * hours + 28 * mins + 53 * secs + 127)).toBe '3 hours 28 mins 53 secs'
     expect(@formatDuration(3 * hours + 53 * secs + 127)).toBe '3 hours 53 secs'

--- a/src/spec-metrics.js
+++ b/src/spec-metrics.js
@@ -56,7 +56,9 @@ SpecMetrics.prototype = {
     if (durationInMins) {
       duration = ' ' + durationInMins + ' mins' + duration;
     }
-    return durationInHrs + ' hours' + duration;
+    return durationInHrs +
+      ' hour' + ((durationInHrs > 1) ? 's' : '') +
+      duration;
   }
 };
 


### PR DESCRIPTION
Just a quick fix so that output where `durationInHrs = 1` displays as `1 hour` instead of `1 hours`