### PR TITLE
fix TypeError: jasmine.getEnv is not a function

### DIFF
--- a/docs/jasmine-npm-configuration.md
+++ b/docs/jasmine-npm-configuration.md
@@ -13,7 +13,7 @@ var noop = function() {};
 
 var jrunner = new Jasmine();
 jrunner.configureDefaultReporter({print: noop});    // remove default reporter logs
-jasmine.getEnv().addReporter(new SpecReporter());   // add jasmine-spec-reporter
+jrunner.addReporter(new SpecReporter());            // add jasmine-spec-reporter
 jrunner.loadConfigFile();                           // load jasmine.json configuration
 jrunner.execute();
 ```


### PR DESCRIPTION
On jasmine v2.4, this guide has an TypeError code.