### PR TITLE
Added support for windows platform to show tick mark and cross symbols

### DIFF
--- a/src/processors/spec-prefixes-processor.js
+++ b/src/processors/spec-prefixes-processor.js
@@ -1,11 +1,21 @@
 var DisplayProcessor = require('../display-processor');
 
 function SpecPrefixesProcessor(prefixes) {
+  var successSymbol = '✓ ',
+      failureSymbol = '✗ ',
+      pendingSymbol = '* ';
+
+  if (process && process.platform === 'win32') {
+    successSymbol = '\u221A ';
+    failureSymbol = '\u00D7 ';
+    pendingSymbol = '* ';
+  }
+
   this.prefixes = {
-    success: prefixes && prefixes.success !== undefined ? prefixes.success : '✓ ',
-    failure: prefixes && prefixes.failure !== undefined ? prefixes.failure : '✗ ',
-    pending: prefixes && prefixes.pending !== undefined ? prefixes.pending : '* '
-  };
+    success: prefixes && prefixes.success !== undefined ? prefixes.success : successSymbol,
+    failure: prefixes && prefixes.failure !== undefined ? prefixes.failure : failureSymbol,
+    pending: prefixes && prefixes.pending !== undefined ? prefixes.pending : pendingSymbol
+  }
 }
 
 SpecPrefixesProcessor.prototype = new DisplayProcessor();


### PR DESCRIPTION
The existing code does not show the symbols properly in git bash console of Windows box. It shows as a '?'. Have fixed it to show the tick and cross symbols properly in Windows