### PR TITLE
Display seed used if specs are randomized

### DIFF
--- a/spec/default-display.spec.coffee
+++ b/spec/default-display.spec.coffee
@@ -285,3 +285,11 @@ describe 'with default display', ->
           @xit 'spec', =>
       ).summary)
       .toContain 'Executed 1 of 4 specs (1 FAILED) (1 PENDING) (2 SKIPPED) in {time}.'
+
+    it 'should report seed', ->
+      expect(new Test(@reporter, ->
+        @describe 'suite 1', =>
+          @it 'spec 1', =>
+            @passed()
+      , false, random: true).summary)
+      .contains /Randomized with seed \d+\./

--- a/spec/helpers/test-helper.coffee
+++ b/spec/helpers/test-helper.coffee
@@ -25,9 +25,9 @@ addMatchers = ->
           pass: false
 
 class Test
-  constructor: (@reporter, @testFn, withColor = false) ->
+  constructor: (@reporter, @testFn, withColor = false, options = { random: false } ) ->
     @init(withColor)
-    @run()
+    @run(options)
 
   init: (withColor) ->
     @outputs = []
@@ -43,7 +43,7 @@ class Test
       else
         @summary.push stuff
 
-  run: ->
+  run: (options) ->
     env = new j$.Env()
     env.passed = ->
       env.expect(true).toBe(true)
@@ -52,6 +52,7 @@ class Test
 
     @testFn.apply(env)
     env.addReporter(@reporter)
+    env.randomizeTests(true) if options.random
     env.execute()
 
 global.Test = Test

--- a/src/jasmine-spec-reporter.js
+++ b/src/jasmine-spec-reporter.js
@@ -71,8 +71,8 @@ SpecReporter.prototype = {
     this.display.jasmineStarted(info);
   },
 
-  jasmineDone: function () {
-    this.metrics.stop();
+  jasmineDone: function (info) {
+    this.metrics.stop(info);
     this.display.summary(this.metrics);
     this.finished = true;
   },

--- a/src/spec-display.js
+++ b/src/spec-display.js
@@ -46,6 +46,10 @@ SpecDisplay.prototype = {
       this.pendingsSummary();
     }
     this.log(execution + successful.success + failed.failure + pending.pending + skipped + duration);
+
+    if (metrics.random) {
+      this.log('Randomized with seed ' + metrics.seed + '.');
+    }
   },
 
   failuresSummary: function () {

--- a/src/spec-metrics.js
+++ b/src/spec-metrics.js
@@ -9,6 +9,8 @@ var SpecMetrics = function () {
   this.skippedSpecs = 0;
   this.totalSpecs = 0;
   this.totalSpecsDefined = 0;
+  this.random = false;
+  this.seed = null;
 };
 
 SpecMetrics.prototype = {
@@ -17,12 +19,14 @@ SpecMetrics.prototype = {
     this.totalSpecsDefined = info && info.totalSpecsDefined ? info.totalSpecsDefined : 0;
   },
 
-  stop: function () {
+  stop: function (info) {
     this.duration = this.formatDuration((new Date()).getTime() - this.startTime);
     this.totalSpecs = this.failedSpecs + this.successfulSpecs + this.pendingSpecs;
     this.executedSpecs = this.failedSpecs + this.successfulSpecs;
     this.totalSpecsDefined = this.totalSpecsDefined ? this.totalSpecsDefined : this.totalSpecs;
     this.skippedSpecs = this.totalSpecsDefined - this.totalSpecs;
+    this.random = info && info.order && info.order.random;
+    this.seed = info && info.order && info.order.seed;
   },
 
   startSpec: function () {


### PR DESCRIPTION
Jasmine allows to randomize tests with `random` and `seed` options. When `seed` is not provided it generates one. It can be useful to see what seed was used if spec suite fails and one wants to re-run it in the same order.

It shows exactly the same message as the default [ConsoleReporter](https://github.com/jasmine/jasmine-npm/blob/master/lib/reporters/console_reporter.js#L92).