### PR TITLE
Remove refs to global jasmine (invoke clearReporters on jrunner.env instead)

### DIFF
--- a/docs/jasmine-npm-configuration.md
+++ b/docs/jasmine-npm-configuration.md
@@ -12,7 +12,7 @@ var SpecReporter = require('jasmine-spec-reporter');
 
 var jrunner = new Jasmine();
 jrunner.configureDefaultReporter({print: noop});    // jasmine < 2.4.1, remove default reporter logs
-jasmine.getEnv().clearReporters();                  // jasmine >= 2.5.2, remove default reporter logs
+jrunner.env.clearReporters();                       // jasmine >= 2.5.2, remove default reporter logs
 jrunner.addReporter(new SpecReporter());            // add jasmine-spec-reporter
 jrunner.loadConfigFile();                           // load jasmine.json configuration
 jrunner.execute();

--- a/example/run-example.js
+++ b/example/run-example.js
@@ -4,7 +4,7 @@ var Jasmine = require('jasmine');
 var SpecReporter = require('../src/jasmine-spec-reporter.js');
 
 var jrunner = new Jasmine();
-jasmine.getEnv().clearReporters();
+jrunner.env.clearReporters();
 jrunner.addReporter(new SpecReporter({
   displayStacktrace: 'none',
   displayFailuresSummary: true,


### PR DESCRIPTION
Thanks for the useful reporter!

This is a minor change aiming to remove references to the global `jasmine` object, in node configuration. The references seem to only be necessary as a means to get to jasmine's `env`, however `jrunner.env` is adequate:

![jasmineenv](https://cloud.githubusercontent.com/assets/1710505/18816305/68705e60-833e-11e6-8242-2e61c112deb3.png)

As `jrunner` (which is plainly `= require('jasmine')`) is already used for all configuration it seems to me as the better choice as an interface to `env`, as opposed to the semi-mysterious `jasmine`.

----

(As a side note, the need for the `clearReporters()` invocation looks like a jasmine defect, since [the docs for 2.5.2](http://jasmine.github.io/2.5/node.html#section-31) claim that 'If you add a reporter through addReporter, the default ConsoleReporter will not be added.' However, in practice it _does_ seem necessary as omitting `clearReporters()` gets me the concole-reporter _and_ whichever other reporter I have added..)