### PR TITLE
feat: stack trace domain filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can customize the output of the reporter yourself: [see how](docs/customize-
   displayPendingSpec: false,      // display each pending spec
   displaySpecDuration: false,     // display each spec duration
   displaySuiteNumber: false,      // display each suite number (hierarchical)
+  filterDomain: 'src/e2e/', // filter to stack that contains src/e2e only
   colors: {
     success: 'green',
     failure: 'red',
@@ -82,4 +83,3 @@ If you want a new feature, you can do the same but some types of features would 
 * options to add extra information to specific sections (spec, suite, summary)
 
 There is already a lot of options, so to add your specific behavior to the reporter, please consider to [build and use your own display processor](docs/customize-output.md).
-

--- a/spec/display-stacktrace-filtering.spec.coffee
+++ b/spec/display-stacktrace-filtering.spec.coffee
@@ -1,0 +1,90 @@
+describe 'with filterDomain', ->
+  describe 'with "/jasmine-spec-reporter" filtering', ->
+    beforeEach ->
+      @reporter = new SpecReporter(filterDomain: 'display-stacktrace-filtering.spec.coffee', displayStacktrace:'all')
+
+    it 'should contains "at Object.<anonymous>" stracktrace', ->
+      expect(new Test(@reporter, ->
+        @describe 'suite 1', =>
+          @it 'spec 1', =>
+            @expect(true).toBe false
+          @describe 'suite 2', =>
+            @it 'spec 2', =>
+              @expect(2).toBe 1
+      ).summary).contains [
+        /.*/
+        /Failures/
+        /.*/
+        ''
+        '1) suite 1 spec 1'
+        '  - Expected true to be false.'
+        /at Object\.<anonymous>/
+        ''
+        '2) suite 1 suite 2 spec 2'
+        '  - Expected 2 to be 1.'
+        /at Object\.<anonymous>/
+        ''
+      ]
+
+    it 'should not contains "at Test.run" stacktrace', ->
+      expect(new Test(@reporter, ->
+        @describe 'suite 1', =>
+          @it 'spec 1', =>
+            @expect(true).toBe false
+          @describe 'suite 2', =>
+            @it 'spec 2', =>
+              @expect(2).toBe 1
+      ).summary).not.contains [
+        /at Test\.run/
+      ]
+
+
+  describe 'undefined', ->
+    beforeEach ->
+      @reporter = new SpecReporter(displayStacktrace:'all')
+
+    it 'should contains "at Object" stracktrace', ->
+      expect(new Test(@reporter, ->
+        @describe 'suite 1', =>
+          @it 'spec 1', =>
+            @expect(true).toBe false
+          @describe 'suite 2', =>
+            @it 'spec 2', =>
+              @expect(2).toBe 1
+      ).summary).contains [
+        /.*/
+        /Failures/
+        /.*/
+        ''
+        '1) suite 1 spec 1'
+        '  - Expected true to be false.'
+        /at Object\.<anonymous>/
+        ''
+        '2) suite 1 suite 2 spec 2'
+        '  - Expected 2 to be 1.'
+        /at Object\.<anonymous>/
+        ''
+      ]
+
+    it 'should contains "at Test.run" stacktrace', ->
+      expect(new Test(@reporter, ->
+        @describe 'suite 1', =>
+          @it 'spec 1', =>
+            @expect(true).toBe false
+          @describe 'suite 2', =>
+            @it 'spec 2', =>
+              @expect(2).toBe 1
+      ).summary).contains [
+        /.*/
+        /Failures/
+        /.*/
+        ''
+        '1) suite 1 spec 1'
+        '  - Expected true to be false.'
+        /at Test\.run/
+        ''
+        '2) suite 1 suite 2 spec 2'
+        '  - Expected 2 to be 1.'
+        /at Test\.run/
+        ''
+      ]

--- a/src/spec-display.js
+++ b/src/spec-display.js
@@ -16,6 +16,7 @@ var SpecDisplay = function (options, displayProcessors) {
   this.displayWithoutColors = options.colors === false;
   this.hasCustomDisplaySpecStarted = options.hasCustomDisplaySpecStarted;
   this.displayProcessors = displayProcessors;
+  this.filterDomain = options.filterDomain;
 
   var displayStacktrace = options.displayStacktrace || 'none';
   this.displaySpecsWithStacktrace = displayStacktrace === 'all' || displayStacktrace === 'specs';
@@ -175,10 +176,17 @@ SpecDisplay.prototype = {
   filterStackTraces: function (traces) {
     var lines = traces.split('\n');
     var filtered = [];
-    for (var i = 1 ; i < lines.length ; i++) {
-      if (!/(jasmine[^\/]*\.js|Timer\.listOnTimeout)/.test(lines[i])) {
-        filtered.push(lines[i]);
-      }
+    for (var i = 1; i < lines.length; i++) {
+        if (!/(jasmine[^\/]*\.js|Timer\.listOnTimeout)/.test(lines[i])) {
+            if (this.filterDomain && lines[i].indexOf('at') !== -1) {
+                if (lines[i].indexOf(this.filterDomain) !== -1) {
+                    //only my domain stacktrace if starts with 'at'
+                    filtered.push(lines[i]);
+                }
+            } else {
+                filtered.push(lines[i]);
+            }
+        }
     }
     return filtered.join('\n' + this.currentIndent);
   },


### PR DESCRIPTION
Allows you to display your stacktrace only, similar to a blackbox feature in chrome debugger.