### PR TITLE
Add low-level print configuration option.

### DIFF
--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -72,7 +72,6 @@ class Test {
         this.outputs = [];
         this.summary = [];
         logInSummary = false;
-        // tslint:disable-next-line:no-unbound-method
         console.log = stuff => {
             if (!withColor) {
                 stuff = stuff.stripColors.stripTime();

--- a/spec/unit/custom-print.spec.ts
+++ b/spec/unit/custom-print.spec.ts
@@ -1,0 +1,122 @@
+describe("spec reporter", () => {
+
+    let outputs: string[];
+
+    describe("with custom print", () => {
+        beforeEach(() => {
+            outputs = [];
+            this.reporter = new global.SpecReporter({
+                colors: {
+                    enabled: false,
+                    },
+                print: line => {
+                    outputs.push(line);
+                },
+                spec: {
+                    displayPending: true
+                }
+            });
+        });
+
+        describe("when jasmine started", () => {
+            it("should report start with ", () => {
+                expect(new Test(this.reporter, function() {
+                    this.describe("suite", () => {
+                        this.it("successful spec", () => {
+                            this.passed();
+                        });
+                    });
+                }).outputs.length).toEqual(0);
+                expect(outputs).contains(/Spec started/);
+            });
+        });
+
+        describe("when suite", () => {
+            it("should report suite with custom print", () => {
+                expect(new Test(this.reporter, function()  {
+                    this.describe("suite", () => {
+                        this.it("successful spec", () => {
+                            this.passed();
+                        });
+                    });
+                }).outputs.length).toEqual(0);
+                expect(outputs).contains(/suite/);
+            });
+        });
+
+        describe("when spec started", () => {
+            it("should report start", () => {
+                expect(new Test(this.reporter, function()  {
+                    this.describe("suite", () => {
+                        this.it("spec to be started", () => {
+                            this.passed();
+                        });
+                    });
+                }).outputs.length).toEqual(0);
+                expect(outputs).contains([
+                    "  suite",
+                    "    " + "✓ spec to be started".green
+                ]);
+            });
+        });
+
+        describe("when spec done", () => {
+            it("should report success with custom print", () => {
+                expect(new Test(this.reporter, function()  {
+                    this.describe("suite", () => {
+                        this.it("successful spec", () => {
+                            this.passed();
+                        });
+                    });
+                }).outputs.length).toEqual(0);
+                expect(outputs).contains(/successful spec/);
+            });
+
+            it("should report failure with custom print", () => {
+                expect(new Test(this.reporter, function()  {
+                    this.describe("suite", () => {
+                        this.it("failed spec", () => {
+                            this.failed();
+                        });
+                    });
+                }).outputs.length).toEqual(0);
+                expect(outputs).contains([/failed spec/]);
+            });
+
+            it("should display spec error messages with custom print", () => {
+                expect(new Test(this.reporter, function()  {
+                    this.describe("suite", () => {
+                        this.it("failed spec", () => {
+                            this.failed();
+                        });
+                    });
+                }).outputs.length).toEqual(0);
+                expect(outputs).contains(["      - Expected true to be false."]);
+            });
+
+            it("should report pending with custom print", () => {
+                expect(new Test(this.reporter, function()  {
+                    this.describe("suite", () => {
+                        this.xit("pending spec", () => {
+                            this.passed();
+                        });
+                    });
+                }).outputs.length).toEqual(0);
+                expect(outputs).contains(/pending spec/);
+            });
+        });
+
+        describe("when summary", () => {
+            it("should display summary error messages with custom print", () => {
+                expect(new Test(this.reporter, function()  {
+                    this.describe("suite", () => {
+                        this.it("failed spec", () => {
+                            this.failed();
+                        });
+                    });
+                }).summary.length).toEqual(0);
+                expect(outputs).contains(["  - Expected true to be false."]);
+            });
+        });
+    });
+});

--- a/src/configuration-parser.ts
+++ b/src/configuration-parser.ts
@@ -19,6 +19,7 @@ export class ConfigurationParser {
             pending: "* ",
             successful: ConfigurationParser.isWindows ? "\u221A " : "✓ ",
         },
+        print: stuff => console.log(stuff),
         spec: {
             displayDuration: false,
             displayErrorMessages: true,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -125,4 +125,10 @@ export class Configuration {
      * options for custom processors
      */
     public customOptions?: any;
+    /**
+     * Low-level printing function, defaults to console.log.
+     * Use process.stdout.write(log + '\n'); to avoid output to
+     * devtools console while still reporting to command line.
+     */
+    public print?: (log: String) => void;
 }

--- a/src/display/logger.ts
+++ b/src/display/logger.ts
@@ -10,12 +10,12 @@ export class Logger {
     private currentIndent = "";
     private lastWasNewLine = false;
 
-    constructor(private displayProcessors: DisplayProcessor[]) {
+    constructor(private displayProcessors: DisplayProcessor[], private print: (line: String) => void) {
     }
 
     public log(stuff: String): void {
         stuff.split("\n").forEach((line: String) => {
-            console.log(line !== "" ? this.currentIndent + line : line);
+            this.print(line !== "" ? this.currentIndent + line : line);
         });
         this.lastWasNewLine = false;
     }
@@ -30,7 +30,7 @@ export class Logger {
 
     public newLine(): void {
         if (!this.lastWasNewLine) {
-            console.log("");
+            this.log("");
             this.lastWasNewLine = true;
         }
     }

--- a/src/spec-reporter.ts
+++ b/src/spec-reporter.ts
@@ -64,7 +64,8 @@ export class SpecReporter implements CustomReporter {
     constructor(configuration?: Configuration) {
         this.configuration = ConfigurationParser.parse(configuration);
         const displayProcessors = SpecReporter.initProcessors(this.configuration);
-        this.logger = new Logger(displayProcessors);
+        const print = this.configuration.print;
+        this.logger = new Logger(displayProcessors, print);
         this.display = new ExecutionDisplay(this.configuration, this.logger, this.specs, displayProcessors);
         this.summary = new SummaryDisplay(this.logger, this.configuration, this.specs);
         this.metrics = new ExecutionMetrics();


### PR DESCRIPTION
Defaults to console.log. Set to function process.stdout.write(log + '\n'); to avoid output to
devtools console while still reporting jasmine results to command line.