### PR TITLE
pending workaround for protractor

### DIFF
--- a/examples/protractor/spec/protractor-spec.js
+++ b/examples/protractor/spec/protractor-spec.js
@@ -8,4 +8,9 @@ describe('angularjs homepage', () => {
 
     expect(greeting.getText()).toEqual('Hello Julie!');
   })
+
+  it('should handle pending specs correctly', () => {
+    pending();
+  })
+
 });

--- a/spec/integration/integration.spec.ts
+++ b/spec/integration/integration.spec.ts
@@ -31,6 +31,9 @@ describe("Integration", () => {
 
     it("with protractor should be ok", done => {
         exec("cd examples/protractor && npm test -s", (error, stdout) => {
+            // workaround for protractor pending error output
+            stdout = stdout.replace(/\[\d+:\d+:\d+\].*\n/, "");
+
             const expected = readFileSync("spec/resources/node-protractor.out", {encoding: "utf-8"});
             const {added, removed} = filter(JsDiff.diffLines(expected, stdout));
             expect(added).toEqual(removed);

--- a/spec/resources/node-protractor.out
+++ b/spec/resources/node-protractor.out
@@ -3,4 +3,11 @@ Spec started
   angularjs homepage
     [32m✓ should greet the named user[39m
 
-Executed 1 of 1 spec[32m SUCCESS[39m.
+**************************************************
+*                    Pending                     *
+**************************************************
+
+1) angularjs homepage should handle pending specs correctly
+  [33mNo reason given[39m
+
+Executed 1 of 2 specs[32m SUCCESS[39m[33m (1 PENDING)[39m.

--- a/src/spec-reporter.ts
+++ b/src/spec-reporter.ts
@@ -96,7 +96,16 @@ export class SpecReporter implements CustomReporter {
 
     public specDone(result: CustomReporterResult): void {
         this.metrics.stopSpec(result);
-        if (result.status === "pending") {
+
+        // remove one protractor can handle "pending" itself
+        let pending = false;
+        for (const failedExpect of result.failedExpectations) {
+            if (failedExpect.message.toLowerCase().indexOf("pending") >= 0) {
+                pending = true;
+            }
+        }
+
+        if (result.status === "pending" || pending) {
             this.metrics.pendingSpecs++;
             this.display.pending(result);
         } else if (result.status === "passed") {


### PR DESCRIPTION
protractor marks pending tests as failed, this fix corrects this behavior...