### PR TITLE
Correct default report from jasmineStarted event

### DIFF
--- a/spec/resources/node-example.out
+++ b/spec/resources/node-example.out
@@ -1,4 +1,4 @@
-Spec started
+Jasmine started
 
   first suite
     [32m✓ should be ok[39m

--- a/spec/resources/node-protractor.out
+++ b/spec/resources/node-protractor.out
@@ -1,4 +1,4 @@
-Spec started
+Jasmine started
 
   angularjs homepage
     [32m✓ should greet the named user[39m

--- a/spec/unit/custom-print.spec.ts
+++ b/spec/unit/custom-print.spec.ts
@@ -31,7 +31,7 @@ describe("spec reporter", () => {
                     },
                     outputs => {
                         expect(outputs.length).toEqual(0);
-                        expect(customOutpouts).contains(/Spec started/);
+                        expect(customOutpouts).contains(/Jasmine started/);
                         done();
                     }
                 );

--- a/spec/unit/custom-processor.spec.ts
+++ b/spec/unit/custom-processor.spec.ts
@@ -24,7 +24,7 @@ describe("spec reporter", () => {
                         });
                     },
                     outputs => {
-                        expect(outputs).contains(/Spec started TEST/);
+                        expect(outputs).contains(/Jasmine started TEST/);
                         done();
                     }
                 );

--- a/spec/unit/default-display.spec.ts
+++ b/spec/unit/default-display.spec.ts
@@ -13,7 +13,7 @@ describe("with default display", () => {
                     });
                 },
                 outputs => {
-                    expect(outputs).contains(/Spec started/);
+                    expect(outputs).contains(/Jasmine started/);
                     done();
                 }
             );

--- a/spec/unit/display-processor.spec.ts
+++ b/spec/unit/display-processor.spec.ts
@@ -21,7 +21,7 @@ describe("spec reporter", () => {
                         });
                     },
                     outputs => {
-                        expect(outputs).contains(/Spec started/);
+                        expect(outputs).contains(/Jasmine started/);
                         done();
                     }
                 );

--- a/src/processors/default-processor.ts
+++ b/src/processors/default-processor.ts
@@ -7,7 +7,7 @@ export class DefaultProcessor extends DisplayProcessor {
     }
 
     public displayJasmineStarted(): string {
-        return "Spec started";
+        return "Jasmine started";
     }
 
     public displaySuite(suite: CustomReporterResult): string {


### PR DESCRIPTION
The event is sent when jasmine execution starts, not when a spec starts executing.

