### PR TITLE
Support reporting errors in afterAll.

### DIFF
--- a/spec/unit/default-display.spec.ts
+++ b/spec/unit/default-display.spec.ts
@@ -457,6 +457,49 @@ describe("with default display", () => {
             );
         });
 
+        it("should report ERRORS when afterAll in suite throws", done => {
+            JasmineEnv.execute(
+                this.reporter,
+                env => {
+                    env.describe("suite", () => {
+                        env.it("spec", () => {
+                            env.passed();
+                        });
+                        env.afterAll(() => {
+                            throw new Error("afterAll threw");
+                        });
+                    });
+                },
+                (outputs, summary) => {
+                    expect(summary).toContain("Executed 1 of 1 spec (1 ERROR) in {time}.");
+                    done();
+                }
+            );
+        });
+
+        it("should report ERRORS when afterAll throws", done => {
+            JasmineEnv.execute(
+                this.reporter,
+                env => {
+                    env.describe("suite", () => {
+                        env.it("spec", () => {
+                            env.passed();
+                        });
+                        env.afterAll(() => {
+                            throw new Error("afterAll in suite threw");
+                        });
+                    });
+                    env.afterAll(() => {
+                        throw new Error("afterAll threw");
+                    });
+                },
+                (outputs, summary) => {
+                    expect(summary).toContain("Executed 1 of 1 spec (2 ERRORS) in {time}.");
+                    done();
+                }
+            );
+        });
+
         it("should report skipped with failure and pending", done => {
             JasmineEnv.execute(
                 this.reporter,

--- a/spec/unit/display-processor.spec.ts
+++ b/spec/unit/display-processor.spec.ts
@@ -139,6 +139,50 @@ describe("spec reporter", () => {
             });
         });
 
+        describe("when suite done", () => {
+            it("should report errors in afterAll", done => {
+                JasmineEnv.execute(
+                    this.reporter,
+                    env => {
+                        env.describe("suite", () => {
+                            env.it("passing spec", () => {
+                                env.passed();
+                            });
+                            env.afterAll(() => {
+                                throw new Error("throw in afterAll in suite");
+                            });
+                        });
+                    },
+                    outputs => {
+                        expect(outputs).contains(/throw in afterAll/);
+                        done();
+                    }
+                );
+            });
+        });
+
+        describe("when jasmine done", () => {
+            it("should report errors in afterAll", done => {
+                JasmineEnv.execute(
+                    this.reporter,
+                    env => {
+                        env.describe("suite", () => {
+                            env.it("passing spec", () => {
+                                env.passed();
+                            });
+                        });
+                        env.afterAll(() => {
+                            throw new Error("throw in afterAll");
+                        });
+                    },
+                    outputs => {
+                        expect(outputs).contains(/throw in afterAll/);
+                        done();
+                    }
+                );
+            });
+        });
+
         describe("when summary", () => {
             it("should display summary error messages", done => {
                 JasmineEnv.execute(

--- a/src/display/execution-display.ts
+++ b/src/display/execution-display.ts
@@ -98,7 +98,10 @@ export class ExecutionDisplay {
         this.suiteHierarchy.push(result);
     }
 
-    public suiteDone(): void {
+    public suiteDone(result: CustomReporterResult): void {
+        if (result && result.failedExpectations && result.failedExpectations.length) {
+            this.failed(result);
+        }
         const suite: CustomReporterResult = this.suiteHierarchy.pop();
         if (this.suiteHierarchyDisplayed[this.suiteHierarchyDisplayed.length - 1] === suite) {
             this.suiteHierarchyDisplayed.pop();

--- a/src/execution-metrics.ts
+++ b/src/execution-metrics.ts
@@ -14,6 +14,7 @@ export class ExecutionMetrics {
     public skippedSpecs = 0;
     public totalSpecsDefined = 0;
     public executedSpecs = 0;
+    public globalErrors: CustomReporterResult[] = [];
     public duration: string;
     public random = false;
     public seed: string;

--- a/src/spec-reporter.ts
+++ b/src/spec-reporter.ts
@@ -78,6 +78,11 @@ export class SpecReporter implements CustomReporter {
 
     public jasmineDone(runDetails: RunDetails): void {
         this.metrics.stop(runDetails);
+        if (runDetails.failedExpectations.length) {
+            const error = this.runDetailsToResult(runDetails);
+            this.metrics.globalErrors.push(error);
+            this.display.failed(error);
+        }
         this.summary.display(this.metrics);
     }
 
@@ -86,7 +91,10 @@ export class SpecReporter implements CustomReporter {
     }
 
     public suiteDone(result: CustomReporterResult): void {
-        this.display.suiteDone();
+        this.display.suiteDone(result);
+        if (result.failedExpectations.length) {
+            this.metrics.globalErrors.push(result);
+        }
     }
 
     public specStarted(result: CustomReporterResult): void {
@@ -107,4 +115,23 @@ export class SpecReporter implements CustomReporter {
             this.display.failed(result);
         }
     }
+
+    private runDetailsToResult(runDetails: RunDetails): CustomReporterResult {
+        return {
+            description: "Non-spec failure",
+            failedExpectations: runDetails.failedExpectations.map(expectation => {
+                return {
+                    actual: "",
+                    expected: "",
+                    matcherName: "",
+                    message: expectation.message,
+                    passed: false,
+                    stack: (expectation as any).stack,
+                };
+            }),
+            fullName: "Non-spec failure",
+            id: "Non-spec failure",
+        };
+    }
+
 }


### PR DESCRIPTION
Starting in jasmine 2.5, errors in afterAll are reported to jasmineDone or suiteDone.
Add ExecutionMetrics.errors to store these errors; report them.

Fixes #210
