### PR TITLE
Feat: display pretty stacktraces

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See full configuration and features: [configuration.ts](src/configuration.ts)
 ## Custom output
 You can customize the output of the reporter yourself: [see how](docs/customize-output.md).
 
-# Developement
+# Development
 
 ## Requirements
 

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -4,7 +4,7 @@ Use jasmine-spec-reporter with TypeScript
 ## Configuration
 
 ```typescript
-import {DisplayProcessor, SpecReporter} from "jasmine-spec-reporter";
+import {DisplayProcessor, SpecReporter, StacktraceOption} from "jasmine-spec-reporter";
 import SuiteInfo = jasmine.SuiteInfo;
 
 class CustomProcessor extends DisplayProcessor {
@@ -15,6 +15,9 @@ class CustomProcessor extends DisplayProcessor {
 
 jasmine.getEnv().clearReporters();
 jasmine.getEnv().addReporter(new SpecReporter({
+    spec: {
+        displayStacktrace: StacktraceOption.NONE
+    },
     customProcessors: [CustomProcessor],
 }));
 ```

--- a/examples/typescript/spec/helpers/reporter.ts
+++ b/examples/typescript/spec/helpers/reporter.ts
@@ -1,4 +1,4 @@
-import {DisplayProcessor, SpecReporter} from "jasmine-spec-reporter";
+import {DisplayProcessor, SpecReporter, StacktraceOption} from "jasmine-spec-reporter";
 import SuiteInfo = jasmine.SuiteInfo;
 
 class CustomProcessor extends DisplayProcessor {
@@ -9,5 +9,8 @@ class CustomProcessor extends DisplayProcessor {
 
 jasmine.getEnv().clearReporters();
 jasmine.getEnv().addReporter(new SpecReporter({
+    spec: {
+        displayStacktrace: StacktraceOption.NONE
+    },
     customProcessors: [CustomProcessor],
 }));

--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -49,6 +49,7 @@ let addMatchers = () => {
                     }
                     return {
                         pass: false,
+                        message: `Expect\n${actual.join("\n")}\nto contains\n${sequence.join("\n")}`
                     };
                 },
             };
@@ -89,6 +90,18 @@ const JasmineEnv = {
         };
         env.failed = () => {
             env.expect(true).toBe(false);
+        };
+        env.failedWithFakeStack = () => {
+            env.addMatchers({
+                throw: () => {
+                    return {
+                        compare: () => {
+                            throw new Error("oops");
+                        }
+                    };
+                }
+            });
+            env.expect().throw();
         };
         testFn(env);
         env.addReporter(reporter);

--- a/spec/unit/configuration-parser.spec.ts
+++ b/spec/unit/configuration-parser.spec.ts
@@ -1,3 +1,4 @@
+import {StacktraceOption} from "../../built/configuration";
 import * as ConfigurationParser from "../../built/configuration-parser";
 import {TestProcessor} from "../helpers/test-processor";
 
@@ -18,5 +19,12 @@ describe("Configuration parser", () => {
 
     it("should add custom options", () => {
         expect(ConfigurationParser.parse({customOptions: {test: "foo"}}).customOptions).toEqual({test: "foo"});
+    });
+
+    it("should warn if outdated `displayStacktrace` boolean value is used", () => {
+        spyOn(console, "warn");
+        expect(ConfigurationParser.parse({spec: {displayStacktrace: true as any}}).spec.displayStacktrace).toEqual(StacktraceOption.NONE);
+        // tslint:disable-next-line:no-unbound-method
+        expect(console.warn).toHaveBeenCalled();
     });
 });

--- a/spec/unit/display-stacktrace.spec.ts
+++ b/spec/unit/display-stacktrace.spec.ts
@@ -1,14 +1,14 @@
-describe("With spec display stacktrace enabled", () => {
+describe("With spec display stacktrace 'raw' enabled", () => {
     beforeEach(() => {
         this.reporter = new global.SpecReporter({
             spec: {
-                displayStacktrace: true
+                displayStacktrace: "raw"
             }
         });
     });
 
     describe("when failed spec", () => {
-        it("should display with error messages with stacktraces", done => {
+        it("should display with error messages with raw stacktraces", done => {
             JasmineEnv.execute(
                 this.reporter,
                 env => {
@@ -36,7 +36,7 @@ describe("With spec display stacktrace enabled", () => {
     });
 
     describe("when summary", () => {
-        it("should not report stacktraces in failures summary", done => {
+        it("should not report raw stacktraces in failures summary", done => {
             JasmineEnv.execute(
                 this.reporter,
                 env => {
@@ -70,17 +70,17 @@ describe("With spec display stacktrace enabled", () => {
     });
 });
 
-describe("With summary display stacktrace enabled", () => {
+describe("With summary display stacktrace 'raw' enabled", () => {
     beforeEach(() => {
         this.reporter = new global.SpecReporter({
             summary: {
-                displayStacktrace: true
+                displayStacktrace: "raw"
             }
         });
     });
 
     describe("when failed spec", () => {
-        it("should not display stacktraces with error messages", done => {
+        it("should not display raw stacktraces with error messages", done => {
             JasmineEnv.execute(
                 this.reporter,
                 env => {
@@ -100,7 +100,7 @@ describe("With summary display stacktrace enabled", () => {
     });
 
     describe("when summary", () => {
-        it("should report failures summary with stacktraces", done => {
+        it("should report failures summary with raw stacktraces", done => {
             JasmineEnv.execute(
                 this.reporter,
                 env => {
@@ -141,11 +141,218 @@ describe("With summary display stacktrace enabled", () => {
     });
 });
 
+describe("With spec display stacktrace 'pretty' enabled", () => {
+    beforeEach(() => {
+        this.reporter = new global.SpecReporter({
+            spec: {
+                displayStacktrace: "pretty"
+            }
+        });
+    });
+
+    describe("when failed spec", () => {
+        it("should display with error messages with pretty stacktraces", done => {
+            JasmineEnv.execute(
+                this.reporter,
+                env => {
+                    env.describe("suite", () => {
+                        env.it("failed spec", () => {
+                            env.failedWithFakeStack();
+                        });
+                    });
+                },
+                outputs => {
+                    expect(outputs).not.contains(/passed assertion/);
+                    expect(outputs).contains([
+                         "    ✗ failed spec",
+                         "      - Error: oops",
+                         "",
+                         /test-helper.js:\d+:\d+/,
+                         "                          return {",
+                         "                              compare: function () {",
+                         "                                  throw new Error(\"oops\");",
+                         "                                        ~",
+                         "                              }",
+                         "                          };",
+                         "",
+                         /test-helper.js:\d+:\d+/,
+                         "                      }",
+                         "                  });",
+                         "                  env.expect().throw();",
+                         "                                    ~",
+                         "              };",
+                         "              testFn(env);",
+                         "",
+                         /display-stacktrace.spec.js:\d+:\d+/,
+                         "                      env.describe(\"suite\", function () {",
+                         "                          env.it(\"failed spec\", function () {",
+                         "                              env.failedWithFakeStack();",
+                         "                                  ~",
+                         "                          });",
+                         "                      });",
+                         ""
+                     ]);
+                    done();
+                }
+            );
+        });
+    });
+
+    describe("when summary", () => {
+        it("should not report pretty stacktraces in failures summary", done => {
+            JasmineEnv.execute(
+                this.reporter,
+                env => {
+                    env.describe("suite 1", () => {
+                        env.it("spec 1", () => {
+                            env.failedWithFakeStack();
+                        });
+                        env.describe("suite 2", () => {
+                            env.it("spec 2", () => {
+                                env.failedWithFakeStack();
+                            });
+                        });
+                    });
+                },
+                (outputs, summary) => {
+                    expect(summary).contains([
+                         /.*/,
+                         /Failures/,
+                         /.*/,
+                         "",
+                         "1) suite 1 spec 1",
+                         "  - Error: oops",
+                         "", "2) suite 1 suite 2 spec 2",
+                         "  - Error: oops",
+                         ""
+                     ]);
+                    done();
+                }
+            );
+        });
+    });
+});
+
+describe("With summary display stacktrace 'pretty' enabled", () => {
+    beforeEach(() => {
+        this.reporter = new global.SpecReporter({
+            summary: {
+                displayStacktrace: "pretty"
+            }
+        });
+    });
+
+    describe("when failed spec", () => {
+        it("should not display pretty stacktraces with error messages", done => {
+            JasmineEnv.execute(
+                this.reporter,
+                env => {
+                    env.describe("suite", () => {
+                        env.it("failed spec", () => {
+                            env.failedWithFakeStack();
+                        });
+                    });
+                },
+                outputs => {
+                    expect(outputs).not.contains(/passed assertion/);
+                    expect(outputs).contains([ "    ✗ failed spec", "      - Error: oops", "" ]);
+                    done();
+                }
+            );
+        });
+    });
+
+    describe("when summary", () => {
+        it("should report failures summary with pretty stacktraces", done => {
+            JasmineEnv.execute(
+                this.reporter,
+                env => {
+                    env.describe("suite 1", () => {
+                        env.it("spec 1", () => {
+                            env.failedWithFakeStack();
+                        });
+                        env.describe("suite 2", () => {
+                            env.it("spec 2", () => {
+                                env.failedWithFakeStack();
+                            });
+                        });
+                    });
+                },
+                (outputs, summary) => {
+                    expect(summary).contains([
+                         /.*/,
+                         /Failures/,
+                         /.*/,
+                         "",
+                         "1) suite 1 spec 1",
+                         "  - Error: oops",
+                         "",
+                         /test-helper.js:\d+:\d+/,
+                         "                      return {",
+                         "                          compare: function () {",
+                         "                              throw new Error(\"oops\");",
+                         "                                    ~",
+                         "                          }",
+                         "                      };",
+                         "",
+                         /test-helper.js:\d+:\d+/,
+                         "                  }",
+                         "              });",
+                         "              env.expect().throw();",
+                         "                                ~",
+                         "          };",
+                         "          testFn(env);",
+                         "",
+                         /display-stacktrace.spec.js:\d+:\d+/,
+                         "                  env.describe(\"suite 1\", function () {",
+                         "                      env.it(\"spec 1\", function () {",
+                         "                          env.failedWithFakeStack();",
+                         "                              ~",
+                         "                      });",
+                         "                      env.describe(\"suite 2\", function () {",
+                         "",
+                         "",
+                         "2) suite 1 suite 2 spec 2",
+                         "  - Error: oops",
+                         "",
+                         /test-helper.js:\d+:\d+/,
+                         "                      return {",
+                         "                          compare: function () {",
+                         "                              throw new Error(\"oops\");",
+                         "                                    ~",
+                         "                          }",
+                         "                      };",
+                         "",
+                         /test-helper.js:\d+:\d+/,
+                         "                  }",
+                         "              });",
+                         "              env.expect().throw();",
+                         "                                ~",
+                         "          };",
+                         "          testFn(env);",
+                         "",
+                         /display-stacktrace.spec.js:\d+:\d+/,
+                         "                      env.describe(\"suite 2\", function () {",
+                         "                          env.it(\"spec 2\", function () {",
+                         "                              env.failedWithFakeStack();",
+                         "                                  ~",
+                         "                          });",
+                         "                      });",
+                         "",
+                         ""
+                     ]);
+                    done();
+                }
+            );
+        });
+    });
+});
+
 describe("With custom stacktrace filter function", () => {
     beforeEach(() => {
         this.reporter = new global.SpecReporter({
             spec: {
-                displayStacktrace: true
+                displayStacktrace: "raw"
             },
             stacktrace: {
                 filter: stacktrace => {
@@ -153,7 +360,7 @@ describe("With custom stacktrace filter function", () => {
                 }
             },
             summary: {
-                displayStacktrace: true
+                displayStacktrace: "raw"
             },
         });
     });

--- a/src/configuration-parser.ts
+++ b/src/configuration-parser.ts
@@ -1,4 +1,4 @@
-import {Configuration} from "./configuration";
+import {Configuration, StacktraceOption} from "./configuration";
 
 export function parse(conf?: Configuration): Configuration {
     return merge(defaultConfiguration, conf);
@@ -24,7 +24,7 @@ const defaultConfiguration: Configuration = {
             displayErrorMessages: true,
             displayFailed: true,
             displayPending: false,
-            displayStacktrace: false,
+            displayStacktrace: StacktraceOption.NONE,
             displaySuccessful: true,
         },
         stacktrace: {
@@ -47,7 +47,7 @@ const defaultConfiguration: Configuration = {
             displayErrorMessages: true,
             displayFailed: true,
             displayPending: true,
-            displayStacktrace: false,
+            displayStacktrace: StacktraceOption.NONE,
             displaySuccessful: false,
         },
     };
@@ -66,6 +66,10 @@ function merge(template: any, override: any): Configuration {
         } else if (override instanceof Object
             && Object.keys(override).indexOf(key) !== -1) {
             result[key] = override[key];
+            if (key === "displayStacktrace" && typeof override[key] === "boolean") {
+                console.warn("WARN: jasmine-spec-reporter 'displayStacktrace' option supports value ('none', 'raw', 'pretty'), default to 'none'\n".yellow);
+                result[key] = StacktraceOption.NONE;
+            }
         } else {
             result[key] = template[key];
         }

--- a/src/configuration-parser.ts
+++ b/src/configuration-parser.ts
@@ -11,6 +11,10 @@ const defaultConfiguration: Configuration = {
             failed: "red",
             pending: "yellow",
             successful: "green",
+            prettyStacktraceFilename: "cyan",
+            prettyStacktraceLineNumber: "yellow",
+            prettyStacktraceColumnNumber: "yellow",
+            prettyStacktraceError: "red",
         },
         customProcessors: [],
         prefixes: {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -99,6 +99,26 @@ export class Configuration {
          * color for pending spec
          */
         pending?: string
+
+        /**
+         * color for pretty stacktrace filename
+         */
+        prettyStacktraceFilename?: string
+
+        /**
+         * color for pretty stacktrace line number
+         */
+        prettyStacktraceLineNumber?: string
+
+        /**
+         * color for pretty stacktrace column number
+         */
+        prettyStacktraceColumnNumber?: string
+
+        /**
+         * color for pretty stacktrace error
+         */
+        prettyStacktraceError?: string
     };
     public prefixes?: {
         /**

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,5 +1,11 @@
 import {DisplayProcessor} from "./display-processor";
 
+export enum StacktraceOption {
+    NONE = "none",
+    RAW = "raw",
+    PRETTY = "pretty",
+}
+
 export class Configuration {
     public suite?: {
         /**
@@ -16,7 +22,7 @@ export class Configuration {
         /**
          * display stacktrace for each failed assertion
          */
-        displayStacktrace?: boolean;
+        displayStacktrace?: StacktraceOption;
 
         /**
          * display each successful spec
@@ -47,7 +53,7 @@ export class Configuration {
         /**
          * display stacktrace for each failed assertion
          */
-        displayStacktrace?: boolean;
+        displayStacktrace?: StacktraceOption;
 
         /**
          * display summary of all successes after execution

--- a/src/display/colors-display.ts
+++ b/src/display/colors-display.ts
@@ -7,5 +7,9 @@ export function init(configuration: Configuration): void {
         failed: configuration.colors.failed,
         pending: configuration.colors.pending,
         successful: configuration.colors.successful,
+        prettyStacktraceFilename: configuration.colors.prettyStacktraceFilename,
+        prettyStacktraceLineNumber: configuration.colors.prettyStacktraceLineNumber,
+        prettyStacktraceColumnNumber: configuration.colors.prettyStacktraceColumnNumber,
+        prettyStacktraceError: configuration.colors.prettyStacktraceError,
     });
 }

--- a/src/display/colors-theme.ts
+++ b/src/display/colors-theme.ts
@@ -3,4 +3,8 @@ interface String {
     successful: string;
     failed: string;
     pending: string;
+    prettyStacktraceFilename:  string;
+    prettyStacktraceLineNumber: string;
+    prettyStacktraceColumnNumber: string;
+    prettyStacktraceError: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,2 +1,3 @@
 export {SpecReporter} from "./spec-reporter";
 export {DisplayProcessor} from "./display-processor";
+export {StacktraceOption} from "./configuration";

--- a/src/processors/default-processor.ts
+++ b/src/processors/default-processor.ts
@@ -1,3 +1,4 @@
+import {StacktraceOption} from "../configuration";
 import {DisplayProcessor} from "../display-processor";
 import {CustomReporterResult} from "../spec-reporter";
 
@@ -34,11 +35,11 @@ export class DefaultProcessor extends DisplayProcessor {
         return DefaultProcessor.displaySpecDescription(spec);
     }
 
-    private displayErrorMessages(spec: CustomReporterResult, withStacktrace: boolean): string {
+    private displayErrorMessages(spec: CustomReporterResult, stacktraceOption: StacktraceOption): string {
         const logs: string[] = [];
         for (const failedExpectation of spec.failedExpectations) {
             logs.push("- ".failed + failedExpectation.message.failed);
-            if (withStacktrace && failedExpectation.stack) {
+            if (stacktraceOption === StacktraceOption.RAW && failedExpectation.stack) {
                 logs.push(this.configuration.stacktrace.filter(failedExpectation.stack));
             }
         }

--- a/src/processors/pretty-errors-processor.ts
+++ b/src/processors/pretty-errors-processor.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import {StacktraceOption} from "../configuration";
 import {DisplayProcessor} from "../display-processor";
 import {CustomReporterResult} from "../spec-reporter";
 
@@ -7,7 +8,15 @@ const CONTEXT = 2;
 
 export class PrettyErrorsProcessor extends DisplayProcessor {
 
-    public displaySpecErrorMessages(spec: CustomReporterResult): string {
+    public displaySpecErrorMessages(spec: CustomReporterResult, log: string): string {
+        return this.configuration.spec.displayStacktrace === StacktraceOption.PRETTY ? this.displayErrorMessages(spec) : log;
+    }
+
+    public displaySummaryErrorMessages(spec: CustomReporterResult, log: string): string {
+        return this.configuration.summary.displayStacktrace === StacktraceOption.PRETTY ? this.displayErrorMessages(spec) : log;
+    }
+
+    private displayErrorMessages(spec: CustomReporterResult) {
         const logs: string[] = [];
         for (const failedExpectation of spec.failedExpectations) {
             logs.push("- ".failed + failedExpectation.message.failed);

--- a/src/processors/pretty-errors-processor.ts
+++ b/src/processors/pretty-errors-processor.ts
@@ -1,0 +1,57 @@
+import * as fs from "fs";
+import {DisplayProcessor} from "../display-processor";
+import {CustomReporterResult} from "../spec-reporter";
+
+const STACK_REG_EXP = /\((.*):(\d+):(\d+)\)/;
+const CONTEXT = 2;
+
+export class PrettyErrorsProcessor extends DisplayProcessor {
+
+    public displaySpecErrorMessages(spec: CustomReporterResult): string {
+        const logs: string[] = [];
+        for (const failedExpectation of spec.failedExpectations) {
+            logs.push("- ".failed + failedExpectation.message.failed);
+            if (failedExpectation.stack) {
+                logs.push(this.prettifyStack(failedExpectation.stack));
+            }
+        }
+        return logs.join("\n");
+    }
+
+    private prettifyStack(stack: string) {
+        const logs: string[] = [];
+        const filteredStack = this.configuration.stacktrace.filter(stack);
+        const stackRegExp = new RegExp(STACK_REG_EXP);
+        filteredStack.split("\n").forEach(stackLine => {
+            if (stackRegExp.test(stackLine)) {
+                const [, filename, lineNb, columnNb] = stackLine.match(stackRegExp);
+                const errorContext = this.retrieveErrorContext(
+                    filename,
+                    parseInt(lineNb, 10),
+                    parseInt(columnNb, 10)
+                );
+
+                logs.push(`${filename.cyan}:${lineNb.yellow}:${columnNb.yellow}`);
+                logs.push(errorContext);
+            }
+        });
+        return `\n${logs.join("\n")}\n`;
+    }
+
+    private retrieveErrorContext(filename: string, lineNb: number, columnNb: number) {
+        const logs = [];
+        const fileLines = fs.readFileSync(filename, "utf-8")
+            .split("\n");
+        for (let i = 0; i < fileLines.length; i++) {
+            const errorLine = lineNb - 1;
+
+            if (i >= errorLine - CONTEXT && i <= errorLine + CONTEXT) {
+                logs.push(fileLines[i]);
+            }
+            if (i === errorLine) {
+                logs.push(" ".repeat(columnNb - 1) + "~".red);
+            }
+        }
+        return logs.join("\n");
+    }
+}

--- a/src/processors/pretty-stacktrace-processor.ts
+++ b/src/processors/pretty-stacktrace-processor.ts
@@ -6,7 +6,7 @@ import {CustomReporterResult} from "../spec-reporter";
 const STACK_REG_EXP = /\((.*):(\d+):(\d+)\)/;
 const CONTEXT = 2;
 
-export class PrettyErrorsProcessor extends DisplayProcessor {
+export class PrettyStacktraceProcessor extends DisplayProcessor {
 
     public displaySpecErrorMessages(spec: CustomReporterResult, log: string): string {
         return this.configuration.spec.displayStacktrace === StacktraceOption.PRETTY ? this.displayErrorMessages(spec) : log;

--- a/src/processors/pretty-stacktrace-processor.ts
+++ b/src/processors/pretty-stacktrace-processor.ts
@@ -33,14 +33,14 @@ export class PrettyStacktraceProcessor extends DisplayProcessor {
         const stackRegExp = new RegExp(STACK_REG_EXP);
         filteredStack.split("\n").forEach(stackLine => {
             if (stackRegExp.test(stackLine)) {
-                const [, filename, lineNb, columnNb] = stackLine.match(stackRegExp);
+                const [, filename, lineNumber, columnNumber] = stackLine.match(stackRegExp);
                 const errorContext = this.retrieveErrorContext(
                     filename,
-                    parseInt(lineNb, 10),
-                    parseInt(columnNb, 10)
+                    parseInt(lineNumber, 10),
+                    parseInt(columnNumber, 10)
                 );
 
-                logs.push(`${filename.cyan}:${lineNb.yellow}:${columnNb.yellow}`);
+                logs.push(`${filename.prettyStacktraceFilename}:${lineNumber.prettyStacktraceLineNumber}:${columnNumber.prettyStacktraceColumnNumber}`);
                 logs.push(errorContext);
             }
         });

--- a/src/processors/pretty-stacktrace-processor.ts
+++ b/src/processors/pretty-stacktrace-processor.ts
@@ -41,10 +41,10 @@ export class PrettyStacktraceProcessor extends DisplayProcessor {
                 );
 
                 logs.push(`${filename.prettyStacktraceFilename}:${lineNumber.prettyStacktraceLineNumber}:${columnNumber.prettyStacktraceColumnNumber}`);
-                logs.push(errorContext);
+                logs.push(`${errorContext}\n`);
             }
         });
-        return `\n${logs.join("\n")}\n`;
+        return `\n${logs.join("\n")}`;
     }
 
     private retrieveErrorContext(filename: string, lineNb: number, columnNb: number) {

--- a/src/spec-reporter.ts
+++ b/src/spec-reporter.ts
@@ -6,7 +6,7 @@ import {Logger} from "./display/logger";
 import {SummaryDisplay} from "./display/summary-display";
 import {ExecutionMetrics} from "./execution-metrics";
 import {DefaultProcessor} from "./processors/default-processor";
-import {PrettyErrorsProcessor} from "./processors/pretty-errors-processor";
+import {PrettyStacktraceProcessor} from "./processors/pretty-stacktrace-processor";
 import {SpecColorsProcessor} from "./processors/spec-colors-processor";
 import {SpecDurationsProcessor} from "./processors/spec-durations-processor";
 import {SpecPrefixesProcessor} from "./processors/spec-prefixes-processor";
@@ -32,7 +32,7 @@ export class SpecReporter implements CustomReporter {
             new DefaultProcessor(configuration),
             new SpecPrefixesProcessor(configuration),
             new SpecColorsProcessor(configuration),
-            new PrettyErrorsProcessor(configuration)
+            new PrettyStacktraceProcessor(configuration)
         ];
 
         if (configuration.spec.displayDuration) {

--- a/src/spec-reporter.ts
+++ b/src/spec-reporter.ts
@@ -6,6 +6,7 @@ import {Logger} from "./display/logger";
 import {SummaryDisplay} from "./display/summary-display";
 import {ExecutionMetrics} from "./execution-metrics";
 import {DefaultProcessor} from "./processors/default-processor";
+import {PrettyErrorsProcessor} from "./processors/pretty-errors-processor";
 import {SpecColorsProcessor} from "./processors/spec-colors-processor";
 import {SpecDurationsProcessor} from "./processors/spec-durations-processor";
 import {SpecPrefixesProcessor} from "./processors/spec-prefixes-processor";
@@ -31,6 +32,7 @@ export class SpecReporter implements CustomReporter {
             new DefaultProcessor(configuration),
             new SpecPrefixesProcessor(configuration),
             new SpecColorsProcessor(configuration),
+            new PrettyErrorsProcessor(configuration)
         ];
 
         if (configuration.spec.displayDuration) {


### PR DESCRIPTION
# Goal

WIth option `displayStacktrace: 'pretty'`, report stacktraces elements in context:

<img width="668" alt="Capture d’écran 2020-03-22 à 15 54 42" src="https://user-images.githubusercontent.com/1331991/77252663-979ead00-6c55-11ea-803b-303eb00c9521.png">

Displayed colors are configurable from colors options:

```js
colors: {
    ...
    prettyStacktraceFilename: "cyan",
    prettyStacktraceLineNumber: "yellow",
    prettyStacktraceColumnNumber: "yellow",
    prettyStacktraceError: "red",
}
```
# Breaking changes

`displayStacktrace` options now take a value among `none`, `raw` and `pretty`.