### PR TITLE
pretty stacktrace: catch uncaught exception on node internal files

### DIFF
--- a/src/processors/pretty-stacktrace-processor.ts
+++ b/src/processors/pretty-stacktrace-processor.ts
@@ -49,8 +49,13 @@ export class PrettyStacktraceProcessor extends DisplayProcessor {
 
     private retrieveErrorContext(filename: string, lineNb: number, columnNb: number) {
         const logs = [];
-        const fileLines = fs.readFileSync(filename, "utf-8")
-            .split("\n");
+        let fileLines;
+        try {
+            fileLines = fs.readFileSync(filename, "utf-8")
+                .split("\n");
+        } catch (error) {
+            return `jasmine-spec-reporter: unable to open '${filename}'\n${error}`;
+        }
         for (let i = 0; i < fileLines.length; i++) {
             const errorLine = lineNb - 1;
 


### PR DESCRIPTION
**What is the current behavior?**

On exception involving node internal files, the stacktrace does not provide the full path which then crash the reporter.

**What is the new behavior?**

Catch exception and display an error message

fix #478
