### PR TITLE
update jasmine-spec-reporter with typescript

### DIFF
--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -4,7 +4,7 @@
 
 ```typescript
 import { DisplayProcessor, SpecReporter, StacktraceOption } from 'jasmine-spec-reporter'
-import SuiteInfo = jasmine.SuiteInfo
+import SuiteInfo = jasmine.JasmineStartedInfo; //SuiteInfo is "deprecated"
 
 class CustomProcessor extends DisplayProcessor {
   public displayJasmineStarted(info: SuiteInfo, log: string): string {


### PR DESCRIPTION
using "jasmine.JasmineStartedInfo" instead of "jasmine.SuiteInfo" because SuiteInfo is deprecated.
